### PR TITLE
Change SFT to metaESDT

### DIFF
--- a/liquidity_pool/src/tokens.rs
+++ b/liquidity_pool/src/tokens.rs
@@ -44,11 +44,12 @@ pub trait TokensModule:
 
         self.send()
             .esdt_system_sc_proxy()
-            .issue_semi_fungible(
+            .register_meta_esdt(
                 issue_cost,
                 &issue_data.name,
                 &issue_data.ticker,
-                SemiFungibleTokenProperties {
+                MetaTokenProperties {
+                    num_decimals: 18,
                     can_freeze: true,
                     can_wipe: true,
                     can_pause: true,

--- a/safety_module/src/lib.rs
+++ b/safety_module/src/lib.rs
@@ -56,11 +56,12 @@ pub trait SafetyModule {
 
         self.send()
             .esdt_system_sc_proxy()
-            .issue_semi_fungible(
+            .register_meta_esdt(
                 issue_cost,
                 &token_display_name,
                 &token_ticker,
-                SemiFungibleTokenProperties {
+                MetaTokenProperties {
+                    num_decimals: 18,
                     can_freeze: true,
                     can_wipe: true,
                     can_pause: true,


### PR DESCRIPTION
Change the lending token generated by Lending Protocol from SFT to
metaESDT to fix the decimal issue.

Issue: ATSDI-1509